### PR TITLE
Updated datauri dependency to ^0.7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/mattdesl"
   },
   "dependencies": {
-    "datauri": "^0.5.5",
+    "datauri": "^0.7.0",
     "js-string-escape": "^1.0.0",
     "static-module": "^1.0.0",
     "through2": "^0.6.3"


### PR DESCRIPTION
It breaks with 0.5.0 because in that version the datauri module exported object can only be used as a class, and urify tries to use it as a function.
