### PR TITLE
Documenation for upgradeing from 1.x to 2.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,54 @@ Returns a through stream inlining `require('urify')` calls to their statically e
 
 Optionally, you can set which `opt.vars` will be used in the [static-eval](https://www.npmjs.org/package/static-eval) in addition to `__dirname` and `___filename`. 
 
+## Upgrade from 1.x to 2.x
+
+There was a signficant breaking change between 1.x and 2.x.  Note the following:
+
+### Specifying what should be urified
+
+`datauri` has been replaced with `urify`.
+
+#### 1.x
+
+```javascript
+var datauri = require('datauri');
+var data = datauri('path/to/file');
+```
+
+#### 2.x
+
+```javascript
+var urify = require('urify');
+var data = urify('path/to/file');
+```
+
+### Specifying Transform
+
+Use `urify/transform` instead of `urify`:
+
+#### 1.x
+
+```json
+  "browserify": {
+    "transform": [
+      "urify"
+    ]
+  }
+```
+
+#### 2.x
+
+```json
+  //2.x
+  "browserify": {
+    "transform": [
+      "urify/transform"
+    ]
+  }
+```
+
+
 ## License
 
 MIT, see [LICENSE.md](http://github.com/mattdesl/urify/blob/master/LICENSE.md) for details.


### PR DESCRIPTION
`urify` has been working great for me for years but recently while doing libary updates, things blew up.  After many hours, I was found that it was a change with `urify`. This patch is to help others so they don't hit the same wall as I did.
