### PR TITLE
Add resolve, following the brfs logic

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "mime": "^1.3.4",
     "quote-stream": "^1.0.2",
     "readable-stream": "^2.0.5",
+    "resolve": "^1.1.7",
     "static-module": "^1.3.0"
   },
   "devDependencies": {

--- a/test/index.js
+++ b/test/index.js
@@ -29,3 +29,20 @@ test('bundles with inline uri', function (t) {
     t.equal(msg, expected);
   }
 });
+
+test('bundles with require.resolve', function (t) {
+  t.plan(1);
+
+  var b = browserify();
+  b.add(__dirname + '/resolve.js');
+  b.transform(path.resolve(__dirname, '..', 'transform.js'));
+
+  b.bundle(function (err, src) {
+    if (err) t.fail(err);
+    vm.runInNewContext(src, { console: { log: log } });
+  });
+
+  function log (msg) {
+    t.equal(msg, expected);
+  }
+});

--- a/test/resolve.js
+++ b/test/resolve.js
@@ -1,0 +1,2 @@
+var uri = require('urify')(require.resolve('./baboon.png'));
+console.log(uri);

--- a/transform.js
+++ b/transform.js
@@ -4,14 +4,20 @@ var quote = require('quote-stream');
 var urify = require('./');
 var fromString = require('from2-string');
 var PassThrough = require('readable-stream/passthrough');
+var resolve = require('resolve');
 
 module.exports = function urifyTransform (file, opts) {
   if (/\.json$/.test(file)) return new PassThrough();
 
+  function resolver (p) {
+    return resolve.sync(p, { basedir: path.dirname(file) });
+  }
+
   if (!opts) opts = {};
   var vars = opts.vars || {
     __filename: file,
-    __dirname: path.dirname(file)
+    __dirname: path.dirname(file),
+    require: { resolve: resolver }
   };
 
   var sm = staticModule(


### PR DESCRIPTION
Hi @mattdesl!

There is a small change to make urify detect `require.resolve()` calls - following the logic of brfs. Sometimes it is the only way to include stuff from sub-package, like I do with [wavefont](https://github.com/audio-lab/wavefont).

Please consider, looking forward.

Thanks!
